### PR TITLE
Basic frame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.rubocop*

--- a/lib/frame.rb
+++ b/lib/frame.rb
@@ -2,25 +2,40 @@ class Frame
   def initialize
     @score = 0
     @rolls = 0
+    @status = :active
   end
 
   def add_roll(roll)
-    raise "Only two rolls can be made per frame" if @rolls >= 2
+    raise "Can no longer add roll to this frame" if @status != :active
     raise ArgumentError.new "A roll must be an integer" unless integer_roll?(roll)
-    raise ArgumentError.new "A roll must be between 0 and 10" if roll < 0 || roll > 10
+    raise ArgumentError.new "A roll must be between 0 and 10" if roll.negative? || roll > 10
     raise "Both rolls cannot add up to more than 10" if @score + roll > 10
     
     @score += roll.to_i
     @rolls += 1
+
+    update_status
   end
 
   def score
     return @score
   end
 
+  def status
+    return @status
+  end
+
   private
 
   def integer_roll?(roll)
-    return roll.is_a?(Integer) || roll % 1 == 0.0
+    return roll.is_a?(Integer) || roll % 1 == 0
+  end
+
+  def update_status
+    if @score == 10
+      @status = :bonus if @score == 10
+    elsif @rolls == 2
+      @status = :done if @rolls == 2
+    end
   end
 end

--- a/lib/frame.rb
+++ b/lib/frame.rb
@@ -1,0 +1,13 @@
+class Frame
+  def initialize
+    @score = 0
+  end
+
+  def add_roll(roll)
+    @score += roll
+  end
+
+  def score
+    return @score
+  end
+end

--- a/lib/frame.rb
+++ b/lib/frame.rb
@@ -1,13 +1,26 @@
 class Frame
   def initialize
     @score = 0
+    @rolls = 0
   end
 
   def add_roll(roll)
-    @score += roll
+    raise "Only two rolls can be made per frame" if @rolls >= 2
+    raise ArgumentError.new "A roll must be an integer" unless integer_roll?(roll)
+    raise ArgumentError.new "A roll must be between 0 and 10" if roll < 0 || roll > 10
+    raise "Both rolls cannot add up to more than 10" if @score + roll > 10
+    
+    @score += roll.to_i
+    @rolls += 1
   end
 
   def score
     return @score
+  end
+
+  private
+
+  def integer_roll?(roll)
+    return roll.is_a?(Integer) || roll % 1 == 0.0
   end
 end

--- a/spec/frame_spec.rb
+++ b/spec/frame_spec.rb
@@ -1,0 +1,23 @@
+require "frame"
+
+RSpec.describe Frame do
+  context "Adds 1 roll" do
+    it "score updates when adding a roll of 5" do
+      frame = Frame.new
+      frame.add_roll(5)
+      expect(frame.score).to eq 5
+    end
+  end
+
+  context "Adds 2 rolls" do
+    it "score updates when adding a roll of 5 and then 4" do
+      frame = Frame.new
+      
+      frame.add_roll(5)
+      expect(frame.score).to eq 5
+      
+      frame.add_roll(4)
+      expect(frame.score).to eq 9
+    end
+  end
+end

--- a/spec/frame_spec.rb
+++ b/spec/frame_spec.rb
@@ -18,8 +18,9 @@ RSpec.describe Frame do
       expect { frame.add_roll(1) }.to_not raise_error
       expect(frame.score).to be 1
 
+      frame = Frame.new
       expect { frame.add_roll(1.0) }.to_not raise_error
-      expect(frame.score).to be 2
+      expect(frame.score).to be 1
     end
     
     it "fails unless roll is between 0 and 10" do
@@ -28,6 +29,18 @@ RSpec.describe Frame do
       error_message = "A roll must be between 0 and 10"
       expect { frame.add_roll(-1) }.to raise_error ArgumentError, error_message
       expect { frame.add_roll(11) }.to raise_error ArgumentError, error_message
+    end
+
+    it "sets the status to bonus for a strike" do
+      frame = Frame.new
+      frame.add_roll(10)
+      expect(frame.score).to eq 10
+      expect(frame.status).to eq :bonus
+
+      frame = Frame.new
+      frame.add_roll(5)
+      expect(frame.score).to eq 5
+      expect(frame.status).to eq :active
     end
   end
   
@@ -40,6 +53,28 @@ RSpec.describe Frame do
       
       frame.add_roll(4)
       expect(frame.score).to eq 9
+    end
+
+    it "updates the status when getting a spare" do
+      frame = Frame.new
+
+      frame.add_roll(5)
+      expect(frame.score).to eq 5
+      expect(frame.status).to eq :active
+      frame.add_roll(5)
+      expect(frame.score).to eq 10
+      expect(frame.status).to eq :bonus
+    end
+
+    it "updates the status when getting below a spare" do
+      frame = Frame.new
+
+      frame.add_roll(5)
+      expect(frame.score).to eq 5
+      expect(frame.status).to eq :active
+      frame.add_roll(4)
+      expect(frame.score).to eq 9
+      expect(frame.status).to eq :done
     end
 
     it "fails if the second roll is not between 0 and 10" do
@@ -69,10 +104,19 @@ RSpec.describe Frame do
       error_message = "Both rolls cannot add up to more than 10"
       expect { frame.add_roll(7) }.to raise_error error_message
     end
+
+    it "fails if the first throw was a strike" do
+      frame = Frame.new
+
+      frame.add_roll(10)
+
+      error_message = "Can no longer add roll to this frame"
+      expect { frame.add_roll(0) }.to raise_error error_message
+    end
   end
   
   context "Adds 3 rolls" do
-    it "raises error since only 2 rolls can be added per frame" do
+    it "fails since only 2 rolls can be added per frame" do
       frame = Frame.new
       
       frame.add_roll(5)
@@ -81,7 +125,7 @@ RSpec.describe Frame do
       frame.add_roll(4)
       expect(frame.score).to eq 9
       
-      error_message = "Only two rolls can be made per frame"
+      error_message = "Can no longer add roll to this frame"
       expect { frame.add_roll(1) }.to raise_error error_message
     end
   end

--- a/spec/frame_spec.rb
+++ b/spec/frame_spec.rb
@@ -7,8 +7,30 @@ RSpec.describe Frame do
       frame.add_roll(5)
       expect(frame.score).to eq 5
     end
-  end
 
+    it "fails unless the roll is an integer" do
+      frame = Frame.new
+
+      error_message = "A roll must be an integer"
+      expect { frame.add_roll(1.5) }.to raise_error ArgumentError, error_message
+      expect { frame.add_roll("Hello world") }.to raise_error ArgumentError, error_message
+      
+      expect { frame.add_roll(1) }.to_not raise_error
+      expect(frame.score).to be 1
+
+      expect { frame.add_roll(1.0) }.to_not raise_error
+      expect(frame.score).to be 2
+    end
+    
+    it "fails unless roll is between 0 and 10" do
+      frame = Frame.new
+
+      error_message = "A roll must be between 0 and 10"
+      expect { frame.add_roll(-1) }.to raise_error ArgumentError, error_message
+      expect { frame.add_roll(11) }.to raise_error ArgumentError, error_message
+    end
+  end
+  
   context "Adds 2 rolls" do
     it "score updates when adding a roll of 5 and then 4" do
       frame = Frame.new
@@ -18,6 +40,49 @@ RSpec.describe Frame do
       
       frame.add_roll(4)
       expect(frame.score).to eq 9
+    end
+
+    it "fails if the second roll is not between 0 and 10" do
+      frame = Frame.new
+
+      frame.add_roll(0)
+      expect(frame.score).to eq 0
+
+      error_message = "A roll must be between 0 and 10"
+      expect { frame.add_roll(-1) }.to raise_error ArgumentError, error_message
+
+      frame = Frame.new
+
+      frame.add_roll(0)
+      expect(frame.score).to eq 0
+
+      error_message = "A roll must be between 0 and 10"
+      expect { frame.add_roll(-1) }.to raise_error ArgumentError, error_message
+    end
+
+    it "fails if both rolls add up to more than 10" do
+      frame = Frame.new
+
+      frame.add_roll(5)
+      expect(frame.score).to eq 5
+
+      error_message = "Both rolls cannot add up to more than 10"
+      expect { frame.add_roll(7) }.to raise_error error_message
+    end
+  end
+  
+  context "Adds 3 rolls" do
+    it "raises error since only 2 rolls can be added per frame" do
+      frame = Frame.new
+      
+      frame.add_roll(5)
+      expect(frame.score).to eq 5
+      
+      frame.add_roll(4)
+      expect(frame.score).to eq 9
+      
+      error_message = "Only two rolls can be made per frame"
+      expect { frame.add_roll(1) }.to raise_error error_message
     end
   end
 end


### PR DESCRIPTION
Adds basic frame functionality:
- Can add up to two rolls (between 0-10) which must add up to at most 10
- Changes the state of the frame to `:bonus` if a strike or a spare is obtained

Functionality not yet added:
- Adding bonus scores to strikes and spares
- Frame 10 behaviour